### PR TITLE
fix unix only separator issue

### DIFF
--- a/allsounds.py
+++ b/allsounds.py
@@ -1,3 +1,4 @@
+import os
 from tkinter import *
 from pygame import mixer
 from math import sqrt, floor
@@ -10,12 +11,12 @@ class AllSounds(object):
 
         self.board_name = 'All Sounds'
         self.ext = 'wav'
-        self.path_tos = ['Sounds/Eric Andre',
-                         'Sounds/Tim and Eric',
-                         'Sounds/Steve Brule',
-                         'Sounds/Lenny Pepperbottom',
-                         'Sounds/Tourettes Guy',
-                         'Sounds/Misc']
+        self.path_tos = [os.path.join('Sounds', 'Eric Andre'),
+                         os.path.join('Sounds', 'Tim and Eric'),
+                         os.path.join('Sounds', 'Steve Brule'),
+                         os.path.join('Sounds', 'Lenny Pepperbottom'),
+                         os.path.join('Sounds', 'Tourettes Guy'),
+                         os.path.join('Sounds', 'Misc')]
 
         self.paths = []
         self.sounds = []
@@ -180,7 +181,7 @@ class AllSounds(object):
         self.filenames = [ea_filenames, te_filenames, sb_filenames, nw_filenames, tg_filenames, misc_filenames]
         for i in range(0, len(self.path_tos)):
             for name in self.filenames[i]:
-                path = '{}/{}.{}'.format(self.path_tos[i], name, self.ext)
+                path = '{}{}{}.{}'.format(self.path_tos[i], os.sep, name, self.ext)
                 self.paths.append(path)
 
         self.count = len(self.paths)

--- a/ericandre.py
+++ b/ericandre.py
@@ -1,3 +1,4 @@
+import os
 from tkinter import *
 from pygame import mixer
 from math import sqrt, floor
@@ -9,7 +10,7 @@ class EricAndre(object):
         self.frame = frame
 
         self.board_name = 'Eric Andre Sounds'
-        self.path_to = 'Sounds/Eric Andre'
+        self.path_to = os.path.join('Sounds', 'Eric Andre')
         self.ext = 'wav'
 
         self.filenames = ['yahBoobay',
@@ -49,7 +50,7 @@ class EricAndre(object):
         self.buttons = []
 
         for name in self.filenames:
-            path = '{}/{}.{}'.format(self.path_to, name, self.ext)
+            path = '{}{}{}.{}'.format(self.path_to, os.sep, name, self.ext)
             self.paths.append(path)
 
         for path in self.paths:

--- a/miscsounds.py
+++ b/miscsounds.py
@@ -1,3 +1,4 @@
+import os
 from tkinter import *
 from pygame import mixer
 from math import sqrt, floor
@@ -9,7 +10,7 @@ class Misc(object):
         self.frame = frame
 
         self.board_name = 'Miscellaneous Sounds'
-        self.path_to = 'Sounds/Misc'
+        self.path_to = os.path.join('Sounds', 'Misc')
         self.ext = 'wav'
 
         self.filenames = ['Yee',
@@ -53,7 +54,7 @@ class Misc(object):
         self.buttons = []
 
         for name in self.filenames:
-            path = '{}/{}.{}'.format(self.path_to, name, self.ext)
+            path = '{}{}{}.{}'.format(self.path_to, os.sep, name, self.ext)
             self.paths.append(path)
 
         for path in self.paths:

--- a/neature.py
+++ b/neature.py
@@ -1,3 +1,4 @@
+import os
 from tkinter import *
 from pygame import mixer
 from math import sqrt, floor
@@ -9,7 +10,7 @@ class Neature(object):
         self.frame = frame
 
         self.board_name = 'Neature Walk Sounds'
-        self.path_to = 'Sounds/Lenny Pepperbottom'
+        self.path_to = os.path.join('Sounds', 'Lenny Pepperbottom')
         self.ext = 'wav'
 
         self.filenames = ['Everyone Knows',
@@ -30,7 +31,7 @@ class Neature(object):
         self.buttons = []
 
         for name in self.filenames:
-            path = '{}/{}.{}'.format(self.path_to, name, self.ext)
+            path = '{}{}{}.{}'.format(self.path_to, os.sep, name, self.ext)
             self.paths.append(path)
 
         for path in self.paths:

--- a/stevebrule.py
+++ b/stevebrule.py
@@ -1,3 +1,4 @@
+import os
 from tkinter import *
 from pygame import mixer
 from math import sqrt, floor
@@ -9,7 +10,7 @@ class SteveBrule(object):
         self.frame = frame
 
         self.board_name = 'Steve Brule Sounds'
-        self.path_to = 'Sounds/Steve Brule'
+        self.path_to = os.path.join('Sounds', 'Steve Brule')
         self.ext = 'wav'
 
         self.filenames = ['Doris Salahari',
@@ -42,7 +43,7 @@ class SteveBrule(object):
         self.buttons = []
 
         for name in self.filenames:
-            path = '{}/{}.{}'.format(self.path_to, name, self.ext)
+            path = '{}{}{}.{}'.format(self.path_to, os.sep, name, self.ext)
             self.paths.append(path)
 
         for path in self.paths:

--- a/timanderic.py
+++ b/timanderic.py
@@ -1,3 +1,4 @@
+import os
 from tkinter import *
 from pygame import mixer
 from math import sqrt, floor
@@ -9,7 +10,7 @@ class TimAndEric(object):
         self.frame = frame
 
         self.board_name = 'Tim and Eric Sounds'
-        self.path_to = 'Sounds/Tim and Eric'
+        self.path_to = os.path.join('Sounds', 'Tim and Eric')
         self.ext = 'wav'
 
         self.filenames = ['Great Job',
@@ -36,7 +37,7 @@ class TimAndEric(object):
         self.buttons = []
 
         for name in self.filenames:
-            path = '{}/{}.{}'.format(self.path_to, name, self.ext)
+            path = '{}{}{}.{}'.format(self.path_to, os.sep, name, self.ext)
             self.paths.append(path)
 
         for path in self.paths:

--- a/tourettesguy.py
+++ b/tourettesguy.py
@@ -1,3 +1,4 @@
+import os
 from tkinter import *
 from pygame import mixer
 from math import sqrt, floor
@@ -9,7 +10,7 @@ class TourettesGuy(object):
         self.frame = frame
 
         self.board_name = 'Tourettes Guy Sounds'
-        self.path_to = 'Sounds/Tourettes Guy'
+        self.path_to = os.path.join('Sounds', 'Tourettes Guy')
         self.ext = 'wav'
 
         self.filenames = ['Ah Shit',
@@ -58,7 +59,7 @@ class TourettesGuy(object):
         self.buttons = []
 
         for name in self.filenames:
-            path = '{}/{}.{}'.format(self.path_to, name, self.ext)
+            path = '{}{}{}.{}'.format(self.path_to, os.sep, name, self.ext)
             self.paths.append(path)
 
         for path in self.paths:


### PR DESCRIPTION
Now should work on windows and unix because `os.sep` and `os.path.join` recognize what system you are on and use the proper separator.